### PR TITLE
Update deprecated z_timeout_end_calc

### DIFF
--- a/src/tpm-tis-spi.c
+++ b/src/tpm-tis-spi.c
@@ -385,7 +385,7 @@ static int tpm_receive(const struct device *dev,
   struct tpm_device_data *tpm = dev->data;
 
   // Calculate deadline (this also handles K_FOREVER)
-  uint64_t deadline = z_timeout_end_calc(timeout);
+  uint64_t deadline = sys_clock_timeout_end_calc(timeout);
 
   // Responde to size query with max size
   if(response_buffer == NULL) {


### PR DESCRIPTION
z_timeout_end_calc was renamed at [PR33302](https://github.com/zephyrproject-rtos/zephyr/pull/33302/)
Also mentioned in: [Release Note Zephyr v2.6.0-rc1](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v2.6.0-rc1)

Tested with Zephyr v3.0.0

Signed-off-by: Benjamin Bigler <benjamin.bigler@securiton.ch>